### PR TITLE
Support JSX and TSX

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -48,7 +48,12 @@ function activate(context) {
 			return completions;
 		}
 	};
-	let disp = vscode.languages.registerCompletionItemProvider(["javascript","typescript"], provider, ["@"]);
+	let disp = vscode.languages.registerCompletionItemProvider([
+		"javascript",
+		"typescript",
+		"javascriptreact",
+		"typescriptreact",
+	], provider, ["@"]);
 	context.subscriptions.push(disp);
 }
 exports.activate = activate;


### PR DESCRIPTION
VSCode has a separate language ID for JSX and TSX files, this change enables jsdoc completion for them by default.